### PR TITLE
1st command executing often times out.

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -1,3 +1,6 @@
+# Timeout for commands executed by starship (in milliseconds).
+command_timeout = 1000
+
 [aws]
 symbol = "  "
 


### PR DESCRIPTION
As temporary measure double command timeout.

```
[WARN] - (starship::utils): Executing command "/usr/local/bin/git" timed out.
[WARN] - (starship::utils): You can set command_timeout in your config to a higher value to allow longer-running commands to keep executing.
```